### PR TITLE
fix(server): remove providing non-existing ceaser service

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,10 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
-import { CaesarService } from './caesar.service';
 
 @Module({
   imports: [],
   controllers: [AppController],
-  providers: [CaesarService],
+  providers: [],
 })
 export class AppModule {}


### PR DESCRIPTION
In previous commit Ceaser Service file was refactored to not be a class service but a file service, only exporting a function called directly.
Removing giving service as a nest provider

Impact: cannot start the server